### PR TITLE
Add Linked v2 Images API

### DIFF
--- a/lib/linked_in/api.rb
+++ b/lib/linked_in/api.rb
@@ -75,6 +75,8 @@ module LinkedIn
 
     def_delegators :@refresh_token, :refresh_token
 
+    def_delegators :@images, :upload_url, :upload_image
+
     private ##############################################################
 
     def initialize_endpoints
@@ -86,6 +88,7 @@ module LinkedIn
       @share_and_social_stream = LinkedIn::ShareAndSocialStream.new(@connection)
       @media = LinkedIn::Media.new(@connection)
       @refresh_token = LinkedIn::RefreshToken.new(@oauth_connection)
+      @images = LinkedIn::Images.new(@connection)
       # @groups = LinkedIn::Groups.new(@connection) not supported by v2 API?
     end
 

--- a/lib/linked_in/images.rb
+++ b/lib/linked_in/images.rb
@@ -23,7 +23,7 @@ module LinkedIn
       response = upload_url(options)
       body = file(image)
       @connection.put(response[:url], body) do |req|
-        req.headers['Content-Type'] = 'image/png'
+        req.headers['Content-Type'] = 'multipart/form-data'
       end
 
       response[:urn]

--- a/lib/linked_in/images.rb
+++ b/lib/linked_in/images.rb
@@ -28,6 +28,10 @@ module LinkedIn
     end
 
     private
+    
+    def params(options)
+      MultiJson.dump({ initializeUploadRequest: options })
+    end
 
     def file(source_url)
       URI.parse(source_url).open { |f| f.read }

--- a/lib/linked_in/images.rb
+++ b/lib/linked_in/images.rb
@@ -1,14 +1,10 @@
 module LinkedIn
-  #
   #  Images API
   # @see https://learn.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/images-api
-  #
   class Images < APIResource
-    #
     #  Initializing the upload
     #  @see https://learn.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/images-api?view=li-lms-2023-05&tabs=http#initialize-image-upload
     #  @options options [String] :owner, the urn of the owner of the image
-    #
     def upload_url(options = {})
       path = "rest/images?action=initializeUpload"
       response =  post(path, params(options))
@@ -17,7 +13,6 @@ module LinkedIn
       { url: value['uploadUrl'], urn: value['image'] }
     end
 
-    #
     #  Uploading the Image
     #  Note: `Content-Type` header although not mentioned in the docs is required, the upload fails with 400 without it.
     #  @see https://learn.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/vector-asset-api?view=li-lms-2023-05&tabs=http#upload-the-image

--- a/lib/linked_in/images.rb
+++ b/lib/linked_in/images.rb
@@ -21,11 +21,7 @@ module LinkedIn
     #  @options options [String] :owner, the urn of the owner of the image
     def upload_image(image, options)
       response = upload_url(options)
-      body = if image.respond_to?(:read)
-               image.read
-             else
-               file(image)
-             end
+      body = file(image)
       @connection.put(response[:url], body) do |req|
         req.headers['Content-Type'] = 'image/png'
       end

--- a/lib/linked_in/images.rb
+++ b/lib/linked_in/images.rb
@@ -1,0 +1,41 @@
+module LinkedIn
+  #
+  #  Images API
+  # @see https://learn.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/images-api
+  #
+  class Images < APIResource
+    #
+    #  Initializing the upload
+    #  @see https://learn.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/images-api?view=li-lms-2023-05&tabs=http#initialize-image-upload
+    #  @options options [String] :owner, the urn of the owner of the image
+    #
+    def upload_url(options = {})
+      path = "rest/images?action=initializeUpload"
+      response =  post(path, params(options))
+      body = JSON.parse(response.body)
+      value = body["value"]
+      { url: value['uploadUrl'], urn: value['image'] }
+    end
+
+    #
+    #  Uploading the Image
+    #  Note: `Content-Type` header although not mentioned in the docs is required, the upload fails with 400 without it.
+    #  @see https://learn.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/vector-asset-api?view=li-lms-2023-05&tabs=http#upload-the-image
+    #  @options options [String] :owner, the urn of the owner of the image
+    def upload_image(image, options)
+      response = upload_url(options)
+      body = file(image)
+      @connection.put(response[:url], body) do |req|
+        req.headers['Content-Type'] = 'image/png'
+      end
+
+      response[:urn]
+    end
+
+    private
+
+    def file(source_url)
+      URI.parse(source_url).open { |f| f.read }
+    end
+  end
+end

--- a/lib/linked_in/images.rb
+++ b/lib/linked_in/images.rb
@@ -1,3 +1,5 @@
+require 'open-uri'
+
 module LinkedIn
   #  Images API
   # @see https://learn.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/images-api

--- a/lib/linked_in/images.rb
+++ b/lib/linked_in/images.rb
@@ -9,7 +9,7 @@ module LinkedIn
     #  @options options [String] :owner, the urn of the owner of the image
     def upload_url(options = {})
       path = "rest/images?action=initializeUpload"
-      response =  post(path, params(options))
+      response = post(path, params(options))
       body = JSON.parse(response.body)
       value = body["value"]
       { url: value['uploadUrl'], urn: value['image'] }
@@ -21,7 +21,11 @@ module LinkedIn
     #  @options options [String] :owner, the urn of the owner of the image
     def upload_image(image, options)
       response = upload_url(options)
-      body = file(image)
+      body = if image.respond_to?(:read)
+               image.read
+             else
+               file(image)
+             end
       @connection.put(response[:url], body) do |req|
         req.headers['Content-Type'] = 'image/png'
       end
@@ -30,7 +34,7 @@ module LinkedIn
     end
 
     private
-    
+
     def params(options)
       MultiJson.dump({ initializeUploadRequest: options })
     end

--- a/lib/linkedin-v2.rb
+++ b/lib/linkedin-v2.rb
@@ -35,6 +35,7 @@ require "linked_in/communications"
 require "linked_in/share_and_social_stream"
 require 'linked_in/media'
 require 'linked_in/refresh_token'
+require 'linked_in/images'
 
 # The primary API object that makes requests.
 # It composes in all of the endpoints

--- a/spec/linked_in/api/images_spec.rb
+++ b/spec/linked_in/api/images_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe LinkedIn::Images do
+  let(:access_token) { 'dummy_access_token' }
+  let(:api) { LinkedIn::API.new(access_token) }
+  let(:response) do
+    {
+      value: {
+        uploadUrl: 'https://sample-linked-in-upload-url.com',
+        image: 'urn:li:image:1212111'
+      }
+    }
+  end
+  let(:expected) do
+    {
+      url: "https://sample-linked-in-upload-url.com",
+      urn: "urn:li:image:1212111",
+    }
+  end
+
+  describe '#upload_url' do
+    it 'returns an upload url' do
+      stub_request(:post, 'https://api.linkedin.com/rest/images?action=initializeUpload').to_return(body: response.to_json)
+      expect(api.upload_url({ 'owner' => 'urn:li:person:121211' }))
+        .to eq(expected)
+    end
+  end
+
+  describe '#upload_image' do
+    it 'uploads the image' do
+      stub_request(:post, 'https://api.linkedin.com/rest/images?action=initializeUpload').to_return(body: response.to_json)
+      stub_request(:put, 'https://sample-linked-in-upload-url.com').with(headers: { 'Content-Type' => 'image/png' })
+      stub_request(:get, 'http://example.org/elvis.png')
+
+      expect(api.upload_image('http://example.org/elvis.png', response))
+        .to eq("urn:li:image:1212111")
+    end
+  end
+end

--- a/spec/linked_in/api/images_spec.rb
+++ b/spec/linked_in/api/images_spec.rb
@@ -29,7 +29,7 @@ describe LinkedIn::Images do
   describe '#upload_image' do
     it 'uploads the image' do
       stub_request(:post, 'https://api.linkedin.com/rest/images?action=initializeUpload').to_return(body: response.to_json)
-      stub_request(:put, 'https://sample-linked-in-upload-url.com').with(headers: { 'Content-Type' => 'image/png' })
+      stub_request(:put, 'https://sample-linked-in-upload-url.com').with(headers: { 'Content-Type' => 'multipart/form-data' })
       stub_request(:get, 'http://example.org/elvis.png')
 
       expect(api.upload_image('http://example.org/elvis.png', response))


### PR DESCRIPTION
This PR adds [Images API](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/images-api?view=li-lms-2023-05&tabs=http) which is required in https://trello.com/c/cdE8XbxV/1101-preview-image-doesnt-appear-on-linkedin-post-when-a-blog-is-shared-using-announce-to-social-media-feature-in-cms for adding preview images to posts.