### PR TITLE
Set LinkedIn API Version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,5 @@ gemspec
 
 group :test do
   gem "coveralls", require: false
+  gem 'timecop', '~> 0.9.2'
 end

--- a/lib/linked_in/api.rb
+++ b/lib/linked_in/api.rb
@@ -1,12 +1,16 @@
+require 'date'
+
 module LinkedIn
   class API
 
-    attr_accessor :access_token
+    attr_accessor :access_token, :linkedin_api_version
 
-    def initialize(access_token=nil)
+    def initialize(access_token=nil, linkedin_api_version=nil)
       access_token = parse_access_token(access_token)
       verify_access_token!(access_token)
       @access_token = access_token
+
+      verify_linkedin_api_version!(linkedin_api_version)
 
       @connection =
         LinkedIn::Connection.new(params: default_params, headers: default_headers) do |conn|
@@ -101,7 +105,7 @@ module LinkedIn
       return {
         "Content-Type" => "application/json",
         "Authorization" => "Bearer #{@access_token.token}",
-        "LinkedIn-Version" => LinkedIn.config.linkedin_version,
+        "LinkedIn-Version" => @linkedin_api_version,
         "X-Restli-Protocol-Version" => "2.0.0"
       }
     end
@@ -123,6 +127,35 @@ module LinkedIn
     def no_access_token_error
       msg = LinkedIn::ErrorMessages.no_access_token
       LinkedIn::InvalidRequest.new(msg)
+    end
+
+    def verify_linkedin_api_version!(version)
+      @linkedin_api_version = if version.nil?
+        recent_linkedin_api_version
+      else
+        validate_linkedin_api_version!(version)
+      end
+    end
+
+    ## Verify the LinkedIn API version provided from caller.
+    # LinkedIn Marketing API Program will publish new versions monthly,
+    # and those versions will be supported for a minimum of one year.
+    # Raise error if version is older than year.(Verifying with 11-months limit)
+    def validate_linkedin_api_version!(version)
+      date = Date.strptime(version,"%Y%m")
+      unless (Date.today - 330) < date
+        msg = LinkedIn::ErrorMessages.unsupported_api_version
+        raise LinkedIn::InvalidRequest.new(msg)
+      end
+
+      version
+    end
+
+    ## Evaluating LinkedIn API version published 60 days before.
+    # Keeping buffer of 60 days to not get affected due to any recent changes
+    # in LinkedIn APIs which might need changes in this gem.
+    def recent_linkedin_api_version
+      (Date.today - 60).strftime("%Y%m")
     end
   end
 end

--- a/lib/linked_in/api.rb
+++ b/lib/linked_in/api.rb
@@ -3,14 +3,14 @@ require 'date'
 module LinkedIn
   class API
 
-    attr_accessor :access_token, :linkedin_api_version
+    attr_accessor :access_token, :api_version
 
-    def initialize(access_token=nil, linkedin_api_version=nil)
+    def initialize(access_token=nil, api_version=nil)
       access_token = parse_access_token(access_token)
       verify_access_token!(access_token)
       @access_token = access_token
 
-      verify_linkedin_api_version!(linkedin_api_version)
+      verify_api_version!(api_version)
 
       @connection =
         LinkedIn::Connection.new(params: default_params, headers: default_headers) do |conn|
@@ -105,7 +105,7 @@ module LinkedIn
       return {
         "Content-Type" => "application/json",
         "Authorization" => "Bearer #{@access_token.token}",
-        "LinkedIn-Version" => @linkedin_api_version,
+        "LinkedIn-Version" => @api_version,
         "X-Restli-Protocol-Version" => "2.0.0"
       }
     end
@@ -129,11 +129,11 @@ module LinkedIn
       LinkedIn::InvalidRequest.new(msg)
     end
 
-    def verify_linkedin_api_version!(version)
-      @linkedin_api_version = if version.nil?
-        recent_linkedin_api_version
+    def verify_api_version!(version)
+      @api_version = if version.nil?
+        recent_api_version
       else
-        validate_linkedin_api_version!(version)
+        validate_api_version!(version)
       end
     end
 
@@ -141,8 +141,8 @@ module LinkedIn
     # LinkedIn Marketing API Program will publish new versions monthly,
     # and those versions will be supported for a minimum of one year.
     # Raise error if version is older than year.(Verifying with 11-months limit)
-    def validate_linkedin_api_version!(version)
-      date = Date.strptime(version,"%Y%m")
+    def validate_api_version!(version)
+      date = Date.strptime(version, '%Y%m')
       unless (Date.today - 330) < date
         msg = LinkedIn::ErrorMessages.unsupported_api_version
         raise LinkedIn::InvalidRequest.new(msg)
@@ -154,8 +154,8 @@ module LinkedIn
     ## Evaluating LinkedIn API version published 60 days before.
     # Keeping buffer of 60 days to not get affected due to any recent changes
     # in LinkedIn APIs which might need changes in this gem.
-    def recent_linkedin_api_version
-      (Date.today - 60).strftime("%Y%m")
+    def recent_api_version
+      (Date.today - 60).strftime('%Y%m')
     end
   end
 end

--- a/lib/linked_in/api.rb
+++ b/lib/linked_in/api.rb
@@ -5,7 +5,7 @@ module LinkedIn
 
     attr_accessor :access_token, :api_version
 
-    def initialize(access_token=nil, api_version=nil)
+    def initialize(access_token = nil, api_version = nil)
       access_token = parse_access_token(access_token)
       verify_access_token!(access_token)
       @access_token = access_token

--- a/lib/linked_in/api.rb
+++ b/lib/linked_in/api.rb
@@ -143,9 +143,11 @@ module LinkedIn
     # Raise error if version is older than year.
     def validate_api_version!(version)
       date = Date.strptime(version, '%Y%m')
-      if (Date.today - 365) > date
+      if (Date.today - 365) >= date
         msg = LinkedIn::ErrorMessages.unsupported_api_version
         raise LinkedIn::InvalidRequest.new(msg)
+      else (Date.today - 335) >= date
+        warn('WARNING: Use the most recent LinkedIn API version to prevent interruptions since your current version of the LinkedIn API is set to expire after a month.')
       end
 
       version

--- a/lib/linked_in/api.rb
+++ b/lib/linked_in/api.rb
@@ -140,10 +140,10 @@ module LinkedIn
     ## Verify the LinkedIn API version provided from caller.
     # LinkedIn Marketing API Program will publish new versions monthly,
     # and those versions will be supported for a minimum of one year.
-    # Raise error if version is older than year.(Verifying with 11-months limit)
+    # Raise error if version is older than year.
     def validate_api_version!(version)
       date = Date.strptime(version, '%Y%m')
-      unless (Date.today - 330) < date
+      if (Date.today - 365) > date
         msg = LinkedIn::ErrorMessages.unsupported_api_version
         raise LinkedIn::InvalidRequest.new(msg)
       end

--- a/lib/linked_in/api.rb
+++ b/lib/linked_in/api.rb
@@ -149,7 +149,7 @@ module LinkedIn
       if (Date.today - 365) >= date
         msg = LinkedIn::ErrorMessages.unsupported_api_version
         raise LinkedIn::InvalidRequest.new(msg)
-      else (Date.today - 335) >= date
+      elsif (Date.today - 335) >= date
         warn('WARNING: Use the most recent LinkedIn API version to prevent interruptions since your current version of the LinkedIn API is set to expire after a month.')
       end
 

--- a/lib/linked_in/configuration.rb
+++ b/lib/linked_in/configuration.rb
@@ -1,5 +1,3 @@
-require 'date'
-
 module LinkedIn
   # Configuration for the LinkedIn gem.
   #
@@ -34,20 +32,9 @@ module LinkedIn
 
     def initialize
       @api = "https://api.linkedin.com"
-      @linkedin_version = set_linkedin_version
       @site = "https://www.linkedin.com"
       @token_url = "/oauth/v2/accessToken"
       @authorize_url = "/oauth/v2/authorization"
-    end
-
-    private
-
-    ## Setting up LinkedIn API version dynamically.
-    # Evaluating LinkedIn API version published 45 days before.
-    # Keeping buffer of 45 days to not get affected due to any recent changes
-    # LinkedIn APIs which might need changes in this gem.
-    def set_linkedin_version
-      (Date.today - 45).strftime("%Y%m")
     end
   end
 end

--- a/lib/linked_in/configuration.rb
+++ b/lib/linked_in/configuration.rb
@@ -1,3 +1,5 @@
+require 'date'
+
 module LinkedIn
   # Configuration for the LinkedIn gem.
   #
@@ -32,10 +34,20 @@ module LinkedIn
 
     def initialize
       @api = "https://api.linkedin.com"
-      @linkedin_version = "202302"
+      @linkedin_version = set_linkedin_version
       @site = "https://www.linkedin.com"
       @token_url = "/oauth/v2/accessToken"
       @authorize_url = "/oauth/v2/authorization"
+    end
+
+    private
+
+    ## Setting up LinkedIn API version dynamically.
+    # Evaluating LinkedIn API version published 45 days before.
+    # Keeping buffer of 45 days to not get affected due to any recent changes
+    # LinkedIn APIs which might need changes in this gem.
+    def set_linkedin_version
+      (Date.today - 45).strftime("%Y%m")
     end
   end
 end

--- a/lib/linked_in/errors.rb
+++ b/lib/linked_in/errors.rb
@@ -47,6 +47,7 @@ module LinkedIn
                   :redirect_uri,
                   :no_auth_code,
                   :no_access_token,
+                  :unsupported_api_version,
                   :credentials_missing,
                   :redirect_uri_mismatch,
                   :throttled
@@ -59,6 +60,8 @@ module LinkedIn
     @no_auth_code = "You must provide the authorization code passed to your redirect uri in the url params"
 
     @no_access_token = "You must have an access token to use LinkedIn's API. Use the LinkedIn::OAuth2 module to obtain an access token"
+
+    @unsupported_api_version = "You must pass valid LinkedIn API version. Verify the LinkedIn API version with LinkedIn docs."
 
     @credentials_missing = "Client credentials do not exist. Please either pass your client_id and client_secret to the LinkedIn::Oauth.new constructor or set them via LinkedIn.configure"
 

--- a/spec/linked_in/api/api_spec.rb
+++ b/spec/linked_in/api/api_spec.rb
@@ -41,11 +41,11 @@ describe LinkedIn::API do
   end
 
   describe 'api_version' do
+    let(:access_token) { 'dummy_access_token' }
     before { Timecop.freeze(2023, 5, 25) }
 
     context 'When no api_version is provided' do
-      let(:access_token) { "dummy_access_token" }
-      subject {LinkedIn::API.new(access_token)}
+      subject { LinkedIn::API.new(access_token) }
 
       it 'sets api_version to recent api version' do
         expect(subject.api_version).to eq('202303')
@@ -53,8 +53,7 @@ describe LinkedIn::API do
     end
 
     context 'When valid api_version is provided' do
-      let(:access_token) { "dummy_access_token" }
-      subject {LinkedIn::API.new(access_token, '202302')}
+      subject { LinkedIn::API.new(access_token, '202302') }
 
       it 'sets api_version to given value' do
         expect(subject.api_version).to eq('202302')
@@ -62,9 +61,7 @@ describe LinkedIn::API do
     end
 
     context 'When older api_version is provided' do
-      let(:access_token) { "dummy_access_token" }
-
-      it 'sets api_version to given value' do
+      it 'raises error' do
         expect {
           LinkedIn::API.new(access_token, '202202')
         }.to raise_error(LinkedIn::InvalidRequest, 'You must pass valid LinkedIn API version. Verify the LinkedIn API version with LinkedIn docs.')

--- a/spec/linked_in/api/api_spec.rb
+++ b/spec/linked_in/api/api_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require "timecop"
 
 describe LinkedIn::API do
   context "With no access token" do
@@ -37,5 +38,37 @@ describe LinkedIn::API do
     subject {LinkedIn::API.new(access_token_obj)}
 
     include_examples "test access token"
+  end
+
+  describe 'api_version' do
+    before { Timecop.freeze(2023, 5, 25) }
+
+    context 'When no api_version is provided' do
+      let(:access_token) { "dummy_access_token" }
+      subject {LinkedIn::API.new(access_token)}
+
+      it 'sets api_version to recent api version' do
+        expect(subject.api_version).to eq('202303')
+      end
+    end
+
+    context 'When valid api_version is provided' do
+      let(:access_token) { "dummy_access_token" }
+      subject {LinkedIn::API.new(access_token, '202302')}
+
+      it 'sets api_version to given value' do
+        expect(subject.api_version).to eq('202302')
+      end
+    end
+
+    context 'When older api_version is provided' do
+      let(:access_token) { "dummy_access_token" }
+
+      it 'sets api_version to given value' do
+        expect {
+          LinkedIn::API.new(access_token, '202202')
+        }.to raise_error(LinkedIn::InvalidRequest, 'You must pass valid LinkedIn API version. Verify the LinkedIn API version with LinkedIn docs.')
+      end
+    end
   end
 end


### PR DESCRIPTION
## <img width="18" src="https://github.trello.services/images/trello-icon.png"> [LinkedIn Social Sharing: Verify LinkedIn API updates.](https://trello.com/c/8xs3tkRS/1314-linkedin-social-sharing-verify-linkedin-api-updates)

- [ ] Feature
- [x] Enhancement
- [ ] Bug fix
- [ ] Documentation update
- [ ] Specs improvement
- [ ] Security fixes

## 📢 Description

> LinkedIn Marketing API Program will publish new versions monthly, and those versions will be supported for a minimum of one (1) year.
> You could choose to integrate with the newest API changes as soon as they’re released or wait until you’re ready - as long as it’s within the one year change API support window.

As mentioned, in their document [here](https://learn.microsoft.com/en-us/linkedin/marketing/versioning?view=li-lms-2023-04#version-cadence), each Linkedin version will be supported for a minimum 1 year before announcing sunset.

Added changes in PR, which will set LinkedIn API version to 45 days before. With these changes, it will make sure:
- Using updated LinkedIn API version.
- No need to keep track on yearly basis if version is updated or not.
- Buffer of 45 days to make sure we are not using any breaking changes.
- In case if any major update, LinkedIn sends updates via mail, so we can keep track of them 