### PR TITLE
Fix wrong Content Type for image uploads

### DIFF
--- a/lib/linked_in/images.rb
+++ b/lib/linked_in/images.rb
@@ -23,7 +23,7 @@ module LinkedIn
       response = upload_url(options)
       body = file(image)
       @connection.put(response[:url], body) do |req|
-        req.headers['Content-Type'] = 'images/*'
+        req.headers['Content-Type'] = 'image/*'
       end
 
       response[:urn]

--- a/lib/linked_in/images.rb
+++ b/lib/linked_in/images.rb
@@ -23,7 +23,7 @@ module LinkedIn
       response = upload_url(options)
       body = file(image)
       @connection.put(response[:url], body) do |req|
-        req.headers['Content-Type'] = 'multipart/form-data'
+        req.headers['Content-Type'] = 'images/*'
       end
 
       response[:urn]

--- a/spec/linked_in/api/images_spec.rb
+++ b/spec/linked_in/api/images_spec.rb
@@ -29,7 +29,7 @@ describe LinkedIn::Images do
   describe '#upload_image' do
     it 'uploads the image' do
       stub_request(:post, 'https://api.linkedin.com/rest/images?action=initializeUpload').to_return(body: response.to_json)
-      stub_request(:put, 'https://sample-linked-in-upload-url.com').with(headers: { 'Content-Type' => 'multipart/form-data' })
+      stub_request(:put, 'https://sample-linked-in-upload-url.com').with(headers: { 'Content-Type' => 'images/*' })
       stub_request(:get, 'http://example.org/elvis.png')
 
       expect(api.upload_image('http://example.org/elvis.png', response))

--- a/spec/linked_in/api/images_spec.rb
+++ b/spec/linked_in/api/images_spec.rb
@@ -29,7 +29,7 @@ describe LinkedIn::Images do
   describe '#upload_image' do
     it 'uploads the image' do
       stub_request(:post, 'https://api.linkedin.com/rest/images?action=initializeUpload').to_return(body: response.to_json)
-      stub_request(:put, 'https://sample-linked-in-upload-url.com').with(headers: { 'Content-Type' => 'images/*' })
+      stub_request(:put, 'https://sample-linked-in-upload-url.com').with(headers: { 'Content-Type' => 'image/*' })
       stub_request(:get, 'http://example.org/elvis.png')
 
       expect(api.upload_image('http://example.org/elvis.png', response))


### PR DESCRIPTION
In https://github.com/marlytics/linkedin-v2/pull/2, wrong Content Type was used for uploading images which caused failures.

This remained unnoticed because of how reference to the changes was being done in https://github.com/marlytics/ll-app/pull/2189/files.

```
branch: 'add-images-api'
```

was used in the gemfile. This does not automatically update the HEAD that it is pointing too after the new changes. So, after the latest fix it was still pointing to the old changes. I recommend not using this to reference changes for the gem as it can cause issues like this.

Using commit hash to define accurate references now.

