### PR TITLE
Update Organizations, Posts, Images API

### DIFF
--- a/lib/linked_in/images.rb
+++ b/lib/linked_in/images.rb
@@ -8,7 +8,7 @@ module LinkedIn
     #  @see https://learn.microsoft.com/en-us/linkedin/marketing/integrations/community-management/shares/images-api?view=li-lms-2023-05&tabs=http#initialize-image-upload
     #  @options options [String] :owner, the urn of the owner of the image
     def upload_url(options = {})
-      path = "rest/images?action=initializeUpload"
+      path = "v2/images?action=initializeUpload"
       response = post(path, params(options))
       body = JSON.parse(response.body)
       value = body["value"]

--- a/lib/linked_in/organizations.rb
+++ b/lib/linked_in/organizations.rb
@@ -40,7 +40,7 @@ module LinkedIn
     # @see https://developer.linkedin.com/docs/guide/v2/organizations/organization-lookup-api#acls
     #
     def organization_acls(options = {})
-      path = 'rest/organizationAcls'
+      path = 'v2/organizationAcls'
       get(path, options)
     end
 

--- a/lib/linked_in/share_and_social_stream.rb
+++ b/lib/linked_in/share_and_social_stream.rb
@@ -58,7 +58,7 @@ module LinkedIn
     # @return [LinkedIn::Mash]
     #
     def share(options = {})
-      path = 'rest/posts'
+      path = 'v2/posts'
       defaults ={
         visibility: "PUBLIC",
         distribution: {

--- a/spec/linked_in/api/images_spec.rb
+++ b/spec/linked_in/api/images_spec.rb
@@ -20,7 +20,7 @@ describe LinkedIn::Images do
 
   describe '#upload_url' do
     it 'returns an upload url' do
-      stub_request(:post, 'https://api.linkedin.com/rest/images?action=initializeUpload').to_return(body: response.to_json)
+      stub_request(:post, 'https://api.linkedin.com/v2/images?action=initializeUpload').to_return(body: response.to_json)
       expect(api.upload_url({ 'owner' => 'urn:li:person:121211' }))
         .to eq(expected)
     end
@@ -28,7 +28,7 @@ describe LinkedIn::Images do
 
   describe '#upload_image' do
     it 'uploads the image' do
-      stub_request(:post, 'https://api.linkedin.com/rest/images?action=initializeUpload').to_return(body: response.to_json)
+      stub_request(:post, 'https://api.linkedin.com/v2/images?action=initializeUpload').to_return(body: response.to_json)
       stub_request(:put, 'https://sample-linked-in-upload-url.com').with(headers: { 'Content-Type' => 'image/*' })
       stub_request(:get, 'http://example.org/elvis.png')
 


### PR DESCRIPTION
## <img width="18" src="https://github.trello.services/images/trello-icon.png"> [LinkedIn Integration: API failing to fetch company page details](https://trello.com/c/21gLvYgE/1646-linkedin-integration-api-failing-to-fetch-company-page-details)

- [ ] Feature
- [ ] Enhancement
- [x] Bug fix
- [ ] Documentation update
- [ ] Specs improvement
- [ ] Security fixes

## 📢 Description

LinkedIn updated API for Organization Lookup. The older APIs were deprecated and moved to the versioned APIs.
Reference: [Linkedin organization-lookup-api](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/community-management/organizations/organization-lookup-api?view=li-lms-2023-10&tabs=http)

![Screenshot 2023-10-30 at 2 52 28 PM](https://github.com/marlytics/linkedin-v2/assets/1950768/7f66e533-43a9-4b3a-8c64-7366e0b40ab5)

