### PR TITLE
Update Faraday version to 2.13

### DIFF
--- a/linkedin-v2.gemspec
+++ b/linkedin-v2.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "oauth2",  "~> 1.0"
   gem.add_dependency "hashie",  ">= 3.2"
-  gem.add_dependency "faraday", "~> 1.0"
+  gem.add_dependency "faraday", "~> 2.1.0"
   gem.add_dependency 'mime-types', '>= 1.16'
 
   gem.add_development_dependency "rake"

--- a/linkedin-v2.gemspec
+++ b/linkedin-v2.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "oauth2",  "~> 1.0"
   gem.add_dependency "hashie",  ">= 3.2"
-  gem.add_dependency "faraday", "~> 2.1.0"
+  gem.add_dependency "faraday", "~> 2.9.2"
   gem.add_dependency 'mime-types', '>= 1.16'
 
   gem.add_development_dependency "rake"

--- a/linkedin-v2.gemspec
+++ b/linkedin-v2.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "oauth2",  "~> 1.0"
   gem.add_dependency "hashie",  ">= 3.2"
-  gem.add_dependency "faraday", "~> 2.9.2"
+  gem.add_dependency "faraday", "~> 2.13"
   gem.add_dependency 'mime-types', '>= 1.16'
 
   gem.add_development_dependency "rake"


### PR DESCRIPTION
## Trello card - [Investigate Mailgun 500 errors & gem upgrade feasibility](https://trello.com/c/dZuRhz33/2517-investigate-mailgun-500-errors-gem-upgrade-feasibility)

### Changes done in this PR
While upgrading the mailgun-ruby gem we got the following error

```
Could not find compatible versions
Because every version of linkedin-v2 depends on faraday ~> 1.0
 and mailgun-ruby >= 1.3.0 depends on faraday ~> 2.1,
 every version of linkedin-v2 is incompatible with mailgun-ruby >= 1.3.0.
So, because Gemfile depends on mailgun-ruby ~> 1.3.0
 and Gemfile depends on linkedin-v2 >= 0,
 version solving has failed.
```

In order the upgrade the mailgun-ruby to its latest version we needed to upgrade the faraday dependency being used by linkedin-v2 gem to `2.13`

**Note: For updating farday to the latest version we have updated the restforce gem in the ll-app `8.0.0` as the current version of restforce `7.3.0` was not compatible with the latest version for faraday**

```
Because every version of linkedin-v2 depends on faraday ~> 2.13.4
  and restforce >= 7.2.0, < 7.4.0 depends on faraday >= 1.1.0, < 2.10.0,
  every version of linkedin-v2 is incompatible with restforce >= 7.2.0, < 7.4.0.
So, because Gemfile depends on linkedin-v2 >= 0
  and Gemfile depends on restforce ~> 7.3.0,
  version solving has failed.
```